### PR TITLE
Deterministic encryption

### DIFF
--- a/lib/ecies.js
+++ b/lib/ecies.js
@@ -33,9 +33,19 @@ ECIES.prototype.publicKey = function(publicKey) {
   return this;
 };
 
-ECIES.prototype.encrypt = function(message) {
+// Encrypts the message (String or Buffer).
+// Optional `ivbuf` contains 16-byte Buffer to be used in AES-CBC.
+// By default, `ivbuf` is computed deterministically from message and private key using HMAC-SHA256.
+// Deterministic IV enables end-to-end test vectors for alternative implementations.
+// Note that identical messages have identical ciphertexts. If your protocol does not include some
+// kind of a sequence identifier inside the message *and* it is important to not allow attacker to learn
+// that message is repeated, then you should use custom IV.
+// For random IV, pass `Random.getRandomBuffer(16)` for the second argument.
+ECIES.prototype.encrypt = function(message, ivbuf) {
   if (!Buffer.isBuffer(message)) message = new Buffer(message);
-  var ivbuf = Random.getRandomBuffer(128 / 8);
+  if (ivbuf === undefined) {
+      ivbuf = Hash.sha256hmac(message, this._privateKey.toBuffer()).slice(0,16);
+  }
 
   var r = this._privateKey.bn;
   var Rpubkey = this._privateKey.publicKey;

--- a/test/ecies.js
+++ b/test/ecies.js
@@ -53,12 +53,13 @@ describe('ECIES', function() {
     .publicKey(aliceKey.publicKey);
 
   var message = 'attack at dawn';
-  var encrypted = '0339e504d6492b082da96e11e8f039796b06cd4855c101e2492a6f10f3e056a9e7499368e41313fa48f71759d13469c28b0bd6ff03a08b2ae5e6679e848f92db4b26a8ccf9c0b43f16eae6216c36380f70724743fe9053c98d94281aa74c94df40';
+  var encrypted = '0339e504d6492b082da96e11e8f039796b06cd4855c101e2492a6f10f3e056a9e712c732611c6917ab5c57a1926973bc44a1586e94a783f81d05ce72518d9b0a80e2e13c7ff7d1306583f9cc7a48def5b37fbf2d5f294f128472a6e9c78dede5f5';
   var encBuf = new Buffer(encrypted, 'hex');
 
   it('correctly encrypts a message', function() {
-    var encrypted = alice.encrypt(message);
-    Buffer.isBuffer(encrypted).should.equal(true);
+    var ciphertext = alice.encrypt(message);
+    Buffer.isBuffer(ciphertext).should.equal(true);
+    ciphertext.toString('hex').should.equal(encrypted)
   });
 
   it('correctly decrypts a message', function() {


### PR DESCRIPTION
Deterministic IV allows completely deterministic behavior that enables two things:

* Complete set of test vectors to use in alternative implementations.
* Black box auditability. A device that uses truly unpredictable numbers (e.g. random IV in AES-CBC, or random k nonce in ECDSA signatures) may potentially leak secret data via those numbers. Also, faulty RNG may lead to critical vulnerabilities. Fully deterministic behavior prevents these kinds of invisible backdoors or bugs.

Note that identical messages are having identical ciphertexts. Usually it's either not critical, or messages already include some sort of timestamps, sequence numbers or unique identifiers. However, if your protocol does not include unique identifiers within plaintext *and* it's critical to not allow someone to learn that two messages are identical, then you should pass `Random.getRandomBuffer(16)` (or better, an alternative deterministic IV) as a second argument to `encrypt` method.