### PR TITLE
refactor such that some of the math is cached

### DIFF
--- a/lib/ecies.js
+++ b/lib/ecies.js
@@ -33,6 +33,40 @@ ECIES.prototype.publicKey = function(publicKey) {
   return this;
 };
 
+ECIES.prototype.Rbuf = function() {
+  if (!this._Rbuf) {
+    var Rpubkey = this._privateKey.publicKey;
+    this._Rbuf = Rpubkey.toDER(true);
+  }
+  return this._Rbuf;
+};
+
+ECIES.prototype.kEkM = function() {
+  if (!this._kEkM) {
+    var r = this._privateKey.bn;
+    var KB = this._publicKey.point;
+    var P = KB.mul(r);
+    var S = P.getX();
+    var Sbuf = S.toBuffer({size: 32});
+    this._kEkM = Hash.sha512(Sbuf);
+  }
+  return this._kEkM;
+};
+
+ECIES.prototype.kE = function() {
+  if (!this._kE) {
+    this._kE = this.kEkM().slice(0, 32);
+  }
+  return this._kE;
+};
+
+ECIES.prototype.kM = function() {
+  if (!this._kM) {
+    this._kM = this.kEkM().slice(32,64);
+  }
+  return this._kM;
+};
+
 // Encrypts the message (String or Buffer).
 // Optional `ivbuf` contains 16-byte Buffer to be used in AES-CBC.
 // By default, `ivbuf` is computed deterministically from message and private key using HMAC-SHA256.
@@ -44,51 +78,25 @@ ECIES.prototype.publicKey = function(publicKey) {
 ECIES.prototype.encrypt = function(message, ivbuf) {
   if (!Buffer.isBuffer(message)) message = new Buffer(message);
   if (ivbuf === undefined) {
-      ivbuf = Hash.sha256hmac(message, this._privateKey.toBuffer()).slice(0,16);
+    ivbuf = Hash.sha256hmac(message, this._privateKey.toBuffer()).slice(0,16);
   }
-
-  var r = this._privateKey.bn;
-  var Rpubkey = this._privateKey.publicKey;
-  var Rbuf = Rpubkey.toDER(true);
-  var KB = this._publicKey.point;
-  var P = KB.mul(r);
-  var S = P.getX();
-  var Sbuf = S.toBuffer({
-    size: 32
-  });
-  var kEkM = Hash.sha512(Sbuf);
-  var kE = kEkM.slice(0, 32);
-  var kM = kEkM.slice(32, 64);
-  var c = AESCBC.encryptCipherkey(message, kE, ivbuf);
-  var d = Hash.sha256hmac(c, kM);
-  var encbuf = Buffer.concat([Rbuf, c, d]);
+  var c = AESCBC.encryptCipherkey(message, this.kE(), ivbuf);
+  var d = Hash.sha256hmac(c, this.kM());
+  var encbuf = Buffer.concat([this.Rbuf(), c, d]);
 
   return encbuf;
 };
 
 ECIES.prototype.decrypt = function(encbuf) {
   $.checkArgument(encbuf);
-
-  var kB = this._privateKey.bn;
   this._publicKey = PublicKey.fromDER(encbuf.slice(0, 33));
-  var R = this._publicKey.point;
-  var P = R.mul(kB);
-  var S = P.getX();
-
-  var Sbuf = S.toBuffer({
-    size: 32
-  });
-  var kEkM = Hash.sha512(Sbuf);
-
-  var kE = kEkM.slice(0, 32);
-  var kM = kEkM.slice(32, 64);
 
   var c = encbuf.slice(33, encbuf.length - 32);
   var d = encbuf.slice(encbuf.length - 32, encbuf.length);
 
-  var d2 = Hash.sha256hmac(c, kM);
+  var d2 = Hash.sha256hmac(c, this.kM());
   if (d.toString('hex') !== d2.toString('hex')) throw new Error('Invalid checksum');
-  var messagebuf = AESCBC.decryptCipherkey(c, kE);
+  var messagebuf = AESCBC.decryptCipherkey(c, this.kE());
 
   return messagebuf;
 };


### PR DESCRIPTION
For applications where a lot of encryption and decryption needs to occur between two parties, cache the shared secret computations.