### PR TITLE
add support for encoding without a public key and using a short tag

### DIFF
--- a/lib/ecies.js
+++ b/lib/ecies.js
@@ -11,10 +11,11 @@ var $ = bitcore.util.preconditions;
 var AESCBC = require('./aescbc');
 
 // http://en.wikipedia.org/wiki/Integrated_Encryption_Scheme
-var ECIES = function ECIES() {
+var ECIES = function ECIES(opts) {
   if (!(this instanceof ECIES)) {
     return new ECIES();
   }
+  this.opts = opts || {};
 };
 
 ECIES.prototype.privateKey = function(privateKey) {
@@ -84,19 +85,32 @@ ECIES.prototype.encrypt = function(message, ivbuf) {
   }
   var c = AESCBC.encryptCipherkey(message, this.kE, ivbuf);
   var d = Hash.sha256hmac(c, this.kM);
-  var encbuf = Buffer.concat([this.Rbuf, c, d]);
-
+  if(this.opts.shortTag) d = d.slice(0,4);
+  if(this.opts.noKey) {
+    var encbuf = Buffer.concat([c, d]);
+  } else {
+    var encbuf = Buffer.concat([this.Rbuf, c, d]);
+  }
   return encbuf;
 };
 
 ECIES.prototype.decrypt = function(encbuf) {
   $.checkArgument(encbuf);
-  this._publicKey = PublicKey.fromDER(encbuf.slice(0, 33));
+  var offset = 0;
+  var tagLength = 32;
+  if(this.opts.shortTag) {
+    tagLength = 4;
+  }
+  if(!this.opts.noKey) {
+    offset = 33;
+    this._publicKey = PublicKey.fromDER(encbuf.slice(0, 33));
+  }
 
-  var c = encbuf.slice(33, encbuf.length - 32);
-  var d = encbuf.slice(encbuf.length - 32, encbuf.length);
+  var c = encbuf.slice(offset, encbuf.length - tagLength);
+  var d = encbuf.slice(encbuf.length - tagLength, encbuf.length);
 
   var d2 = Hash.sha256hmac(c, this.kM);
+  if(this.opts.shortTag) d2 = d2.slice(0,4);
   if (d.toString('hex') !== d2.toString('hex')) throw new Error('Invalid checksum');
   var messagebuf = AESCBC.decryptCipherkey(c, this.kE);
 

--- a/test/ecies.js
+++ b/test/ecies.js
@@ -85,9 +85,43 @@ describe('ECIES', function() {
     decrypted.should.equal(secret);
   });
 
+  it('roundtrips (no public key)', function() {
+    alice.opts.noKey = true;
+    bob.opts.noKey = true;
+    var secret = 'some secret message!!!';
+    var encrypted = alice.encrypt(secret);
+    var decrypted = bob
+      .decrypt(encrypted)
+      .toString();
+    decrypted.should.equal(secret);
+  });
+
+  it('roundtrips (short tag)', function() {
+    alice.opts.shortTag = true;
+    bob.opts.shortTag = true;
+    var secret = 'some secret message!!!';
+    var encrypted = alice.encrypt(secret);
+    var decrypted = bob
+      .decrypt(encrypted)
+      .toString();
+    decrypted.should.equal(secret);
+  });
+
+  it('roundtrips (no public key & short tag)', function() {
+    alice.opts.noKey = true;
+    alice.opts.shortTag = true;
+    bob.opts.noKey = true;
+    bob.opts.shortTag = true;
+    var secret = 'some secret message!!!';
+    var encrypted = alice.encrypt(secret);
+    var decrypted = bob
+      .decrypt(encrypted)
+      .toString();
+    decrypted.should.equal(secret);
+  });
+
   it('errors', function() {
     should.exist(bitcore.errors.ECIES);
   });
-
 
 });


### PR DESCRIPTION
This adds support for shorted (but non ECIES standard) encodings.  You can drop the embedding of the public key and use only the first 4 bytes of the HMAC (saving 61 bytes if both options are used).  This can be helpful in circumstances where message size is a concern.